### PR TITLE
国外填报版本

### DIFF
--- a/.github/workflows/automate.yml
+++ b/.github/workflows/automate.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ Abroad-expand ]
+    branches: [ main ]
   pull_request:
-    branches: [ Abroad-expand ]
+    branches: [ main ]
   schedule:
     - cron:  '0 2 * * *'
   workflow_dispatch:

--- a/.github/workflows/automate.yml
+++ b/.github/workflows/automate.yml
@@ -2,9 +2,9 @@ name: Go
 
 on:
   push:
-    branches: [ master ]
+    branches: [ Abroad-expand ]
   pull_request:
-    branches: [ master ]
+    branches: [ Abroad-expand ]
   schedule:
     - cron:  '0 2 * * *'
   workflow_dispatch:

--- a/main.py
+++ b/main.py
@@ -144,12 +144,17 @@ class Zlapp(Fudan):
         last_info = get_info.json()
 
         print("◉上一次提交日期为:", last_info["d"]["info"]["date"])
+        # 地区得先从oldInfo中提取
+        last_area = last_info["d"]["oldInfo"]["area"]
+        print("◉上一次提交的地区是:", last_area)
+        if last_area == "其他国家":
+            pass
+        else:
+            position = last_info["d"]["info"]['geo_api_info']
+            position = json_loads(position)
 
-        position = last_info["d"]["info"]['geo_api_info']
-        position = json_loads(position)
-
-        print("◉上一次提交地址为:", position['formattedAddress'])
-        # print("◉上一次提交GPS为", position["position"])
+            print("◉上一次提交地址为:", position['formattedAddress'])
+            # print("◉上一次提交GPS为", position["position"])
         # print(last_info)
         
         # 改为上海时区
@@ -201,28 +206,45 @@ class Zlapp(Fudan):
         }
 
         print("\n\n◉◉提交中")
-
-        geo_api_info = json_loads(self.last_info["geo_api_info"])
         province = self.last_info["province"]
         city = self.last_info["city"]
-        district = geo_api_info["addressComponent"].get("district", "")
+        area = self.last_info["area"]
+        if area == "其他国家":
+            gwszdd = self.last_info["gwszdd"]
+        else:
+            geo_api_info = json_loads(self.last_info["geo_api_info"])
+            district = geo_api_info["addressComponent"].get("district", "")
         
         while(True):
             print("◉正在识别验证码......")
             code = self.validate_code()
             print("◉验证码为:", code)
-            self.last_info.update(
-                {
-                    "tw": "13",
-                    "province": province,
-                    "city": city,
-                    "area": " ".join((province, city, district)),
-                    #"sfzx": "1",  # 是否在校
-                    #"fxyy": "",  # 返校原因
-                    "code": code,
-                }
-            )
-            # print(self.last_info)
+            if area == "其他国家":
+                self.last_info.update(
+                    {
+                        "tw": "13",
+                        "province": province,
+                        "city": city,
+                        "area": area,
+                        "gwszdd": gwszdd,
+                        #"sfzx": "1",  # 是否在校
+                        #"fxyy": "",  # 返校原因
+                        "code": code,
+                    }
+                )
+            else:
+                self.last_info.update(
+                    {
+                        "tw": "13",
+                        "province": province,
+                        "city": city,
+                        "area": " ".join((province, city, district)),
+                        #"sfzx": "1",  # 是否在校
+                        #"fxyy": "",  # 返校原因
+                        "code": code,
+                    }
+                )
+            print(self.last_info)
             save = self.session.post(
                 'https://zlapp.fudan.edu.cn/ncov/wap/fudan/save',
                 data=self.last_info,


### PR DESCRIPTION
增加了对地区为"其他国家"的pafd填报适配。（时区仍然以上海为准）
运行时会输出上一次提交的地区，如: "◉上一次提交的地区是: 其他国家"

只是用if语句进行分支判断，可能有疏漏，请检查是否对国内版本有影响